### PR TITLE
blackの更新

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==21.8b0
+black==22.3.0
 django==3.2.12
 django-debug-toolbar==3.2.2
 flake8==3.9.2


### PR DESCRIPTION
次のエラーを修正するため、blackのバージョンを上げる。

> ImportError: cannot import name '_unicodefun' from 'click' (/home/circleci/repo/venv/lib/python3.9/site-packages/click/__init__.py)
